### PR TITLE
fix: 상세 검색에서 종목형 & 지수형 동시 검색되는 오류 수정

### DIFF
--- a/lib/views/detail_search_modal.dart
+++ b/lib/views/detail_search_modal.dart
@@ -40,7 +40,7 @@ class _DetailSearchModalState extends State<DetailSearchModal> {
 
   Future<void> _getFilteredData() async {
     String? equityType = null;
-    if (_isStock && _isStock) {
+    if (_isStock && _isIndex) {
       equityType = "MIX";
     } else if (_isIndex) {
       equityType = "INDEX";


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
#27 
<!---- Resolves: #(Isuue Number) -->
상품 상세 검색 시 종목형만 선택했을 때도 혼합형으로 검색되는 버그가 있었는데, 코드 상에 오류가 있었어서 해결했습니다.
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 팀 Notion에 있는 Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
