### PR TITLE
feat: 전일 대비 종가 데이터를 상품 화면 상단에 적용

### DIFF
--- a/lib/data/providers/ticker_symbol_provider.dart
+++ b/lib/data/providers/ticker_symbol_provider.dart
@@ -1,9 +1,16 @@
 import 'package:elswhere/data/models/dtos/response_ticker_symbol_dto.dart';
 import 'package:elswhere/data/services/els_product_service.dart';
 import 'package:flutter/material.dart';
+import 'package:yahoo_finance_data_reader/yahoo_finance_data_reader.dart';
 
 class TickerSymbolProvider extends ChangeNotifier {
   List<ResponseTickerSymbolDto> _tickers = [];
+  final List<String> _stockIndex = ['KOSPI200', 'S&P500', 'EUROSTOXX50', 'NIKKEI225', 'HSCEI'];
+  final List<String> _tickerSymbol = ['KS200', 'GSPC', 'STOXX50E', 'N225', 'HSCE'];
+  final List<double> _price = List.filled(5, 0);
+  final List<double> _rate = List.filled(5, 0);
+  final int _length = 5;
+  final _yfinanceReader = const YahooFinanceDailyReader();
   bool _isLoading = false;
 
   final ProductService _productService;
@@ -11,6 +18,11 @@ class TickerSymbolProvider extends ChangeNotifier {
   TickerSymbolProvider(this._productService);
 
   List<ResponseTickerSymbolDto> get tickers => _tickers;
+  List<String> get stockIndex => _stockIndex;
+  List<String> get tickerSymbol => _tickerSymbol;
+  List<double> get rate => _rate;
+  List<double> get price => _price;
+  int get length => _length;
   bool get isLoading => _isLoading;
 
   Future<void> fetchTickers() async {
@@ -24,6 +36,22 @@ class TickerSymbolProvider extends ChangeNotifier {
     } finally {
       _isLoading = false;
       notifyListeners();
+    }
+  }
+
+  Future<void> fetchStockPrices() async {
+    for(int i = 0; i < _length ; i++) {
+      final String stock = _tickerSymbol[i];
+      final now = DateTime.now();
+      final twoDaysAgo = now.subtract(const Duration(days: 2));
+      final response = await _yfinanceReader.getDailyDTOs('^$stock', startDate: twoDaysAgo);
+      final candlesData = response.candlesData;
+      if (candlesData.isNotEmpty) {
+        final day1ago = candlesData.last.close;
+        final day2ago = candlesData.first.close;
+        _price[i] = day1ago;
+        _rate[i] = (day1ago - day2ago) / day2ago * 100.0;
+      }
     }
   }
 }

--- a/lib/ui/screens/initial_screen.dart
+++ b/lib/ui/screens/initial_screen.dart
@@ -16,24 +16,29 @@ class InitialScreen extends StatelessWidget {
       future: Future.wait([
         Provider.of<IssuerProvider>(context, listen: false).fetchIssuers(),
         Provider.of<TickerSymbolProvider>(context, listen: false).fetchTickers(),
+        Provider.of<TickerSymbolProvider>(context, listen: false).fetchStockPrices(),
       ]),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {
           return Scaffold(
-            body: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                const CircularProgressIndicator(
-                  color: AppColors.mainBlue,
-                ),
-                Text(
-                  '데이터 로딩중 입니다...',
-                  style: Theme.of(context).textTheme.displaySmall?.copyWith(
-                    color: AppColors.contentBlack,
-                    fontSize: 12,
+            body: Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  const CircularProgressIndicator(
+                    color: AppColors.mainBlue,
                   ),
-                ),
-              ],
+                  const SizedBox(height: 16,),
+                  Text(
+                    '데이터 로딩중 입니다...',
+                    style: Theme.of(context).textTheme.displaySmall?.copyWith(
+                      color: AppColors.contentBlack,
+                      fontSize: 12,
+                    ),
+                  ),
+                ],
+              ),
             ),
           );
         } else if (snapshot.hasError) {

--- a/lib/ui/screens/product_screen.dart
+++ b/lib/ui/screens/product_screen.dart
@@ -42,12 +42,12 @@ class _ProductScreenState extends State<ProductScreen> with SingleTickerProvider
   
   Future<void> typeChanged(BuildContext context, String? value) async {
     //TODO: ProductProvider에 따라서 on sale end sale 구분해서 refresh 해야함
-    // switch(_tabIndex) {
-      // case 0:
+    switch(_tabIndex) {
+      case 0:
         await Provider.of<ELSOnSaleProductsProvider>(context, listen: false).refreshProducts(value!);
-      // case 1:
+      case 1:
         await Provider.of<ELSEndSaleProductsProvider>(context, listen: false).refreshProducts(value!);
-    // }
+    }
     setState(() {
       selectedValue = value!;
       type = widget.itemsMap[value]!;
@@ -68,7 +68,7 @@ class _ProductScreenState extends State<ProductScreen> with SingleTickerProvider
           padding: edgeInsetsAll8,
           child: StockIndexCardSwiper(),
         ),
-        leadingWidth: 300,
+        leadingWidth: double.infinity,
         actions: [
           Padding(
             padding: edgeInsetsAll8,
@@ -80,15 +80,10 @@ class _ProductScreenState extends State<ProductScreen> with SingleTickerProvider
         ],
       ),
       body: Padding(
-        padding: const EdgeInsets.all(8.0),
+        padding: edgeInsetsAll8,
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // const Text(
-            //   'ELS 상품',
-            //   style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-            // ),
-            // const SizedBox(height: 16),
             const Row(
               children: [
                 Expanded(
@@ -222,6 +217,7 @@ class _ProductScreenState extends State<ProductScreen> with SingleTickerProvider
                 child: FittedBox(
                   fit: BoxFit.fitHeight,
                   child: CircleAvatar(
+                    backgroundColor: AppColors.contentWhite,
                     child: Text(
                       '$_count',
                       style: Theme.of(context).textTheme.labelMedium?.copyWith(
@@ -230,7 +226,6 @@ class _ProductScreenState extends State<ProductScreen> with SingleTickerProvider
                         fontWeight: FontWeight.w700,
                       ),
                     ),
-                    backgroundColor: AppColors.contentWhite,
                   ),
                 ),
               )

--- a/lib/ui/widgets/els_product_card.dart
+++ b/lib/ui/widgets/els_product_card.dart
@@ -161,8 +161,8 @@ class _ELSProductCardState extends State<ELSProductCard> {
               ),
               AnimatedContainer(
                 curve: Curves.fastOutSlowIn,
-                duration: Duration(milliseconds: 500),
-                transform: Matrix4.translationValues(isSelected ? -190 : 0, 0, 0),
+                duration: const Duration(milliseconds: 500),
+                transform: Matrix4.translationValues(isSelected ? -200 : 0, 0, 0),
                 child: Container(
                   height: cardHeight,
                   padding: edgeInsetsAll16,
@@ -179,11 +179,11 @@ class _ELSProductCardState extends State<ELSProductCard> {
                       Column(
                         children: [
                           CircleAvatar(
+                            backgroundColor: const Color(0xFFF5F6F6),
                             child: Padding(
-                              padding: const EdgeInsets.all(4.0),
+                              padding: edgeInsetsAll4,
                               child: Image.asset(Assets.iconHana),
                             ),
-                            backgroundColor: const Color(0xFFF5F6F6),
                           ),
                         ],
                       ),

--- a/lib/ui/widgets/stock_index_card_swiper.dart
+++ b/lib/ui/widgets/stock_index_card_swiper.dart
@@ -1,70 +1,97 @@
-import 'package:elswhere/config/app_resource.dart';
-import 'package:flutter/material.dart';
 import 'package:card_swiper/card_swiper.dart';
+import 'package:elswhere/config/app_resource.dart';
+import 'package:elswhere/data/providers/ticker_symbol_provider.dart';
+import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
 
 class StockIndexCardSwiper extends StatefulWidget {
-  final List<String> stockIndex = [
-    'KOSPI200', 'S&P500', 'EUROSTOXX50'
-  ];
-  final List<double> price = [
-    1457.3, 22345.4, 5656.7
-  ];
-  final List<double> rate = [
-    1.2, -3.4, 5.6
-  ];
-
-  StockIndexCardSwiper({super.key});
+  const StockIndexCardSwiper({super.key});
 
   @override
-  State<StockIndexCardSwiper> createState() => _StockIndexCardSwiperState();
+  State<StockIndexCardSwiper> createState() => StockIndexCardSwiperState();
 }
 
-class _StockIndexCardSwiperState extends State<StockIndexCardSwiper> {
+class StockIndexCardSwiperState extends State<StockIndexCardSwiper> {
   final NumberFormat priceFormat = NumberFormat.decimalPattern();
   final NumberFormat percentageFormat = NumberFormat.percentPattern();
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: edgeInsetsAll8,
-      child: Swiper(
-        itemBuilder: (context, index) {
-          return Row(
-            children: [
-              Text(
-                widget.stockIndex[index],
-                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                  letterSpacing: -0.02,
-                ),
+    return Consumer<TickerSymbolProvider>(
+      builder: (context, tickerSymbolProvider, child) {
+        if (tickerSymbolProvider.isLoading && tickerSymbolProvider.stockIndex.isEmpty) {
+          return const Center(child: CircularProgressIndicator());
+        } else if (tickerSymbolProvider.stockIndex.isEmpty) {
+          return const Center(child: Text('준비 중입니다.'));
+        } else {
+          return IgnorePointer(
+            child: Padding(
+              padding: edgeInsetsAll8,
+              child: Swiper(
+                itemBuilder: (context, index) {
+                  return Row(
+                    children: [
+                      Text(
+                        tickerSymbolProvider.stockIndex[index],
+                        style: Theme
+                            .of(context)
+                            .textTheme
+                            .headlineSmall
+                            ?.copyWith(
+                          letterSpacing: -0.02,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        priceFormat.format(tickerSymbolProvider.price[index]),
+                        style: Theme
+                            .of(context)
+                            .textTheme
+                            .headlineSmall
+                            ?.copyWith(
+                          color: tickerSymbolProvider.rate[index] > 0
+                              ? AppColors.contentRed
+                              : (tickerSymbolProvider.rate[index] != 0
+                              ? AppColors.mainBlue
+                              : Color(0xFF595E62)),
+                          letterSpacing: -0.02,
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Text(
+                        // percentageFormat.format(tickerSymbolProvider.rate[index]),
+                        '${tickerSymbolProvider.rate[index] > 0
+                            ? '+'
+                            : ''}${tickerSymbolProvider.rate[index]
+                            .toStringAsPrecision(2)}%',
+                        style: Theme
+                            .of(context)
+                            .textTheme
+                            .headlineSmall
+                            ?.copyWith(
+                          color: tickerSymbolProvider.rate[index] > 0
+                              ? AppColors.contentRed
+                              : (tickerSymbolProvider.rate[index] != 0
+                              ? AppColors.mainBlue
+                              : Color(0xFF595E62)),
+                          letterSpacing: -0.02,
+                        ),
+                      ),
+                    ],
+                  );
+                },
+                itemCount: tickerSymbolProvider.length,
+                autoplay: true,
+                autoplayDelay: 4000,
+                scrollDirection: Axis.vertical,
+                axisDirection: AxisDirection.down,
+                duration: 1000,
               ),
-              const SizedBox(width: 8),
-              Text(
-                priceFormat.format(widget.price[index]),
-                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                  color: widget.rate[index] > 0 ? AppColors.contentRed : AppColors.mainBlue,
-                  letterSpacing: -0.02,
-                ),
-              ),
-              const SizedBox(width: 8),
-              Text(
-                // percentageFormat.format(widget.rate[index]),
-                '${widget.rate[index] > 0 ? '+' : ''}${widget.rate[index]}%',
-                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                  color: widget.rate[index] > 0 ? AppColors.contentRed : AppColors.mainBlue,
-                  letterSpacing: -0.02,
-                ),
-              ),
-            ],
+            ),
           );
-        },
-        itemCount: 3,
-        autoplay: true,
-        autoplayDelay: 5000,
-        scrollDirection: Axis.vertical,
-        axisDirection: AxisDirection.down,
-        duration: 1000,
-      )
+        }
+      },
     );
   }
 }


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
#65 #66  
<!---- Resolves: #(Isuue Number) -->
모바일 측에서 Yahoo Finance API를 활용하여 실제 주가 지수의 전일 종가와 그 전일 종가 데이터를 가져온 후, 상품 화면 좌상단에 시각적으로 보일 수 있도록 기능을 추가하였습니다.
## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 팀 Notion에 있는 Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
