### PR TITLE
fix: 로그아웃 / 회원탈퇴 후 재로그인 시 닉네임 잘못 받아오는 오류 수정

### DIFF
--- a/lib/config/config.dart
+++ b/lib/config/config.dart
@@ -1,7 +1,10 @@
+import 'package:dio/dio.dart';
+
 const String appName = "ELSwhere";
 const String errorMessage = "문제가 발생했습니다.";
 const String callbackUrlScheme = "elswhere";
 const String googleIconPath = "assets/icons/icon_google.svg";
+late final Dio dio;
 late final String baseUrl;
 late final String loginEndpoint;
 late String accessToken;

--- a/lib/data/providers/user_info_provider.dart
+++ b/lib/data/providers/user_info_provider.dart
@@ -21,19 +21,7 @@ class UserInfoProvider with ChangeNotifier {
   String getNickname() => _nickname;
 
 
-  UserInfoProvider(this._userService) {
-    _initializeNickname();
-  }
-
-
-  Future<void> _initializeNickname() async {
-    final httpResponse = await _userService.checkUser();
-    final response = httpResponse.response;
-    final data = response.data;
-    final userInfo = ResponseUserInfoDto.fromJson(data);
-    _nickname = userInfo.nickname;
-    notifyListeners();
-  }
+  UserInfoProvider(this._userService);
 
   Future<bool> checkUser() async {
     try {
@@ -43,6 +31,7 @@ class UserInfoProvider with ChangeNotifier {
       final userInfo = ResponseUserInfoDto.fromJson(data);
 
       _userInfo = userInfo;
+      _nickname = _userInfo!.nickname;
       return true;
     } on DioException catch (e) {
       if (e.response?.statusCode == 404) {

--- a/lib/data/services/dio_client.dart
+++ b/lib/data/services/dio_client.dart
@@ -1,0 +1,30 @@
+import 'package:dio/dio.dart';
+import 'package:elswhere/config/config.dart';
+
+class DioClient {
+  static Dio createDio() {
+    final dio = Dio();
+
+    dio.interceptors.add(InterceptorsWrapper(
+      onRequest: (options, handler) {
+        options.headers["Authorization"] = accessToken;
+        return handler.next(options);
+      },
+      onResponse: (response, handler) {
+        if (response.statusCode == 200) {
+          print('응답 + $response');
+          return handler.next(response);
+        } else {
+          print('Error!');
+        }
+      },
+      onError: (DioException e, handler) {
+        print(e);
+        // 에러 처리
+        return handler.next(e);
+      },
+    ));
+
+    return dio;
+  }
+}

--- a/lib/data/services/user_service.dart
+++ b/lib/data/services/user_service.dart
@@ -21,31 +21,3 @@ abstract class UserService {
   @DELETE("/v1/user")
   Future<HttpResponse> deleteUser();
 }
-
-class DioClient {
-  static Dio createDio() {
-    final dio = Dio();
-
-    dio.interceptors.add(InterceptorsWrapper(
-      onRequest: (options, handler) {
-        options.headers["Authorization"] = accessToken;
-        return handler.next(options);
-      },
-      onResponse: (response, handler) {
-        if (response.statusCode == 200) {
-          print('응답 + $response');
-          return handler.next(response);
-        } else {
-          print('Error!');
-        }
-      },
-      onError: (DioException e, handler) {
-        print(e);
-        // 에러 처리
-        return handler.next(e);
-      },
-    ));
-
-    return dio;
-  }
-}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,3 @@
-import 'package:dio/dio.dart';
 import 'package:elswhere/config/app_resource.dart';
 import 'package:elswhere/config/config.dart';
 import 'package:elswhere/data/providers/els_product_provider.dart';
@@ -6,10 +5,9 @@ import 'package:elswhere/data/providers/els_products_provider.dart';
 import 'package:elswhere/data/providers/issuer_provider.dart';
 import 'package:elswhere/data/providers/ticker_symbol_provider.dart';
 import 'package:elswhere/data/providers/user_info_provider.dart';
+import 'package:elswhere/data/services/dio_client.dart';
 import 'package:elswhere/data/services/els_product_service.dart';
 import 'package:elswhere/data/services/user_service.dart';
-import 'package:elswhere/ui/screens/login_screen.dart';
-import 'package:elswhere/ui/screens/main_screen.dart';
 import 'package:elswhere/ui/screens/splash_screen.dart';
 import 'package:elswhere/utils/material_color_builder.dart';
 import 'package:flutter/material.dart';
@@ -18,7 +16,6 @@ import 'package:flutter_native_splash/flutter_native_splash.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
   await initApp();
@@ -42,14 +39,13 @@ Future<void> initApp() async {
 }
 
 class ELSwhere extends StatelessWidget {
-  final Dio _dio = Dio();
-  final Dio _userDio = DioClient.createDio();
   late final ProductService _productService;
   late final UserService _userService;
 
   ELSwhere({super.key}) {
-    _productService = ProductService(_dio);
-    _userService = UserService(_userDio);
+    dio = DioClient.createDio();
+    _productService = ProductService(dio);
+    _userService = UserService(dio);
   }
 
   @override

--- a/lib/ui/screens/initial_screen.dart
+++ b/lib/ui/screens/initial_screen.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:elswhere/config/app_resource.dart';
 import 'package:elswhere/data/providers/issuer_provider.dart';
 import 'package:elswhere/data/providers/ticker_symbol_provider.dart';
+import 'package:elswhere/data/providers/user_info_provider.dart';
 import 'package:elswhere/ui/screens/main_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -17,6 +18,7 @@ class InitialScreen extends StatelessWidget {
         Provider.of<IssuerProvider>(context, listen: false).fetchIssuers(),
         Provider.of<TickerSymbolProvider>(context, listen: false).fetchTickers(),
         Provider.of<TickerSymbolProvider>(context, listen: false).fetchStockPrices(),
+        Provider.of<UserInfoProvider>(context, listen: false).checkUser(),
       ]),
       builder: (context, snapshot) {
         if (snapshot.connectionState == ConnectionState.waiting) {

--- a/lib/ui/screens/login_screen.dart
+++ b/lib/ui/screens/login_screen.dart
@@ -2,7 +2,6 @@ import 'package:elswhere/config/app_resource.dart';
 import 'package:elswhere/config/config.dart';
 import 'package:elswhere/data/services/auth_service.dart';
 import 'package:elswhere/ui/screens/initial_screen.dart';
-import 'package:elswhere/ui/screens/main_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:fluttertoast/fluttertoast.dart';
@@ -44,12 +43,11 @@ class LoginScreen extends StatelessWidget {
                     SizedBox(
                       width: width - 32,
                       child: OutlinedButton.icon(
-                        style: const ButtonStyle(
-                          padding: WidgetStatePropertyAll(edgeInsetsAll12),
-                          shape: WidgetStatePropertyAll(RoundedRectangleBorder(
-                              borderRadius: borderRadiusCircular10)),
+                        style: OutlinedButton.styleFrom(
+                          padding: edgeInsetsAll12,
+                          shape: const RoundedRectangleBorder(borderRadius: borderRadiusCircular10),
                           backgroundColor:
-                              WidgetStatePropertyAll(AppColors.contentWhite),
+                              AppColors.contentWhite,
                         ),
                         icon: SvgPicture.asset(
                           googleIconPath,
@@ -95,10 +93,9 @@ class LoginScreen extends StatelessWidget {
     final response = await AuthService.authenticateUser(authUrl);
     if (response != null) {
       accessToken = response.accessToken;
+      refreshToken = response.refreshToken;
       storage.write(key: 'ACCESS_TOKEN', value: accessToken);
       storage.write(key: 'REFRESH_TOKEN', value: refreshToken);
-      print(accessToken);
-      print(refreshToken);
       return true;
     }
     return false;


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
#80 
<!---- Resolves: #(Isuue Number) -->
회원탈퇴 및 로그아웃 후 같은 사용자가 다른 계정으로 재로그인 시 사용자 닉네임 정보가 수정되지 않는 현상을 수정했습니다.
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 팀 Notion에 있는 Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
