### PR TITLE
fix: 일부 기종에서 상품 리스트 아이템의 밑부분의 픽셀이 overflow가 나는 현상 수정

### DIFF
--- a/lib/ui/widgets/els_product_card.dart
+++ b/lib/ui/widgets/els_product_card.dart
@@ -27,7 +27,7 @@ class ELSProductCard extends StatefulWidget {
 
 class _ELSProductCardState extends State<ELSProductCard> {
   bool isSelected = false;
-  final cardHeight = 100.0;
+  final cardHeight = 105.0;
 
   @override
   Widget build(BuildContext context) {
@@ -248,7 +248,6 @@ class _ELSProductCardState extends State<ELSProductCard> {
                                 ),
                               ],
                             ),
-                            const SizedBox(height: 6),
                             Text(
                               '${productType[widget.product.productType]!}형',
                               style: const TextStyle(color: AppColors.mainBlue),


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
#90 
<!---- Resolves: #(Isuue Number) -->
일부 기종에서 상품 목록 리스트 내 아이템의 밑 부분이 Overflow나는 오류를 수정했습니다.
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 팀 Notion에 있는 Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
