### PR TITLE
fix: 상품 상세 목록 내 비고란 Text Overflow시 렌더링 오류 현상 수정

### DIFF
--- a/lib/ui/views/els_product_detail_view.dart
+++ b/lib/ui/views/els_product_detail_view.dart
@@ -162,7 +162,7 @@ class ELSProductDetailView extends StatelessWidget {
                   const SizedBox(height: 8),
                   _buildProductTypeCard(),
                   const SizedBox(height: 8),
-                  _buildRemarksCard(),
+                  _buildRemarksCard(context),
                   const SizedBox(height: 48),
                   _buildTitleText('기초자산 주가'),
                   const SizedBox(height: 24),
@@ -371,7 +371,8 @@ class ELSProductDetailView extends StatelessWidget {
     );
   }
 
-  Widget _buildRemarksCard() {
+  Widget _buildRemarksCard(BuildContext context) {
+
     return Container(
       decoration: const BoxDecoration(
         color: AppColors.contentWhite,
@@ -379,8 +380,8 @@ class ELSProductDetailView extends StatelessWidget {
       ),
       child: Padding(
         padding: edgeInsetsAll16,
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             Text(
               '비고',
@@ -388,10 +389,11 @@ class ELSProductDetailView extends StatelessWidget {
                 color: AppColors.textGray,
               ),
             ),
+            const SizedBox(height: 10,),
             Text(
               '${product!.remarks}형',
               style: textTheme.labelMedium!.copyWith(),
-            ),
+            )
           ],
         ),
       ),


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
#93 
<!---- Resolves: #(Isuue Number) -->
상품 상세 페이지 내 비고란에 들어갈 텍스트가 일정 길이가 이상이 되면 렌더링 오류가 생겨 이를 수정하였습니다.
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 팀 Notion에 있는 Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
