### PR TITLE
hotfix: 상세 검색 시 오늘 마감인 상품이 청약 종료 탭에서 나타나는 오류 수정

### DIFF
--- a/lib/data/providers/els_products_provider.dart
+++ b/lib/data/providers/els_products_provider.dart
@@ -63,14 +63,15 @@ class ELSProductsProvider extends ChangeNotifier {
 
   // 07-22 상품 검색 구현하면서 try 함수
   Future<void> fetchFilteredProducts(RequestProductSearchDto body) async {
+    final now = DateTime.now().copyWith(hour: 0, minute: 0, second: 0, millisecond: 0, microsecond: 0);
     resetProducts();
     _isLoading = true;
     notifyListeners();
     try {
       final responsePage = await _productService.fetchFilteredProducts(body);
       _products += responsePage.content.where((e) => status == 'on'
-          ? e.subscriptionEndDate.compareTo(DateTime.now()) >= 0
-          : e.subscriptionEndDate.compareTo(DateTime.now()) < 0).toList();
+          ? e.subscriptionEndDate.compareTo(now) >= 0
+          : e.subscriptionEndDate.compareTo(now) < 0).toList();
       _hasNext = responsePage.hasNext;
       _page++;
     } catch (error) {


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
#143 
<!---- Resolves: #(Isuue Number) -->
청약 마감 당일 상품에 대해서 청약 종료 상품에서 표시되는 문제를 수정했습니다.
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 팀 Notion에 있는 Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
