### PR TITLE
feat: 메인 화면에서 뒤로가기 두 번 누를 시 앱 종료 설정

### DIFF
--- a/lib/ui/screens/main_screen.dart
+++ b/lib/ui/screens/main_screen.dart
@@ -1,3 +1,4 @@
+import 'package:elswhere/config/app_resource.dart';
 import 'package:elswhere/ui/screens/more_screen.dart';
 import 'package:elswhere/ui/screens/product_screen.dart';
 import 'package:elswhere/ui/widgets/drawer_widget.dart';
@@ -10,8 +11,9 @@ class MainScreen extends StatefulWidget {
   State<MainScreen> createState() => _MainScreenState();
 }
 
-class _MainScreenState extends State<MainScreen> {
+class _MainScreenState extends State<MainScreen> with WidgetsBindingObserver {
   int _selectedIndex = 0;
+  DateTime? lastPressed;
 
   final List<Widget> _pages = [
     HomeScreen(),
@@ -23,6 +25,38 @@ class _MainScreenState extends State<MainScreen> {
     setState(() {
       _selectedIndex = index;
     });
+  }
+
+  Future<bool> _onWillPop() async {
+    final now = DateTime.now();
+
+    if (lastPressed == null ||
+        now.difference(lastPressed!) > const Duration(seconds: 2)) {
+      lastPressed = now;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+            '한 번 더 누르면 종료됩니다.',
+            style: textTheme.displayMedium
+          ),
+          duration: const Duration(seconds: 2),
+        ),
+      );
+      return true; // Prevent pop
+    }
+    return false; // Allow pop
+  }
+
+  @override
+  Future<bool> didPopRoute() async {
+    final result = await _onWillPop();
+    return result;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
   }
 
   @override


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
#157 
<!---- Resolves: #(Isuue Number) -->
위젯 트리 최상단 메인 화면에서 뒤로가기 버튼을 두 번 누를 시 앱을 종료하도록 설정했습니다.
## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 팀 Notion에 있는 Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
