### PR TITLE
fix: 상품 선택 후 상세 페이지로 넘어가면 카드 선택 유무가 초기화되도록 수정

### DIFF
--- a/lib/data/models/dtos/response_single_product_dto.dart
+++ b/lib/data/models/dtos/response_single_product_dto.dart
@@ -11,7 +11,7 @@ class ResponseSingleProductDto {
   final int equityCount;
   final int? knockIn;
   final String volatilites;
-  final String earlyRepaymentEvaluationDates;
+  final String? earlyRepaymentEvaluationDates;
   final String issuedDate;
   final String maturityDate;
   final double yieldIfConditionsMet;
@@ -35,7 +35,7 @@ class ResponseSingleProductDto {
     required this.equityCount,
     this.knockIn,
     required this.volatilites,
-    required this.earlyRepaymentEvaluationDates,
+    this.earlyRepaymentEvaluationDates,
     required this.issuedDate,
     required this.maturityDate,
     required this.yieldIfConditionsMet,

--- a/lib/data/models/dtos/response_single_product_dto.g.dart
+++ b/lib/data/models/dtos/response_single_product_dto.g.dart
@@ -17,7 +17,7 @@ ResponseSingleProductDto _$ResponseSingleProductDtoFromJson(
       knockIn: (json['knockIn'] as num?)?.toInt(),
       volatilites: json['volatilites'] as String,
       earlyRepaymentEvaluationDates:
-          json['earlyRepaymentEvaluationDates'] as String,
+          json['earlyRepaymentEvaluationDates'] as String?,
       issuedDate: json['issuedDate'] as String,
       maturityDate: json['maturityDate'] as String,
       yieldIfConditionsMet: (json['yieldIfConditionsMet'] as num).toDouble(),

--- a/lib/ui/views/els_product_detail_view.dart
+++ b/lib/ui/views/els_product_detail_view.dart
@@ -444,7 +444,7 @@ class ELSProductDetailView extends StatelessWidget {
   }
 
   Widget _buildEvaluationDatesList() {
-    final List<String> rows = product!.earlyRepaymentEvaluationDates.split(',');
+    final List<String> rows = product!.earlyRepaymentEvaluationDates?.split(',') ?? [];
     final List<List<String>> evaluationDates = rows.map((row) => row.trim().split(':')).toList();
     return Column(
       children: [

--- a/lib/ui/views/els_product_list_view.dart
+++ b/lib/ui/views/els_product_list_view.dart
@@ -61,6 +61,7 @@ class ELSProductListView<T extends ELSProductsProvider> extends StatelessWidget 
                           itemCount: productsProvider.products.length,
                           itemBuilder: (context, index) {
                             return ELSProductCard(
+                              key: ValueKey(productsProvider.products[index].id),
                               product: productsProvider.products[index],
                               index: index,
                               checkCompare: checkCompare,
@@ -90,6 +91,7 @@ class ELSProductListView<T extends ELSProductsProvider> extends StatelessWidget 
                       itemCount: productsProvider.similarProducts!.results.length,
                       itemBuilder: (context, index) {
                         return ELSProductCard(
+                          key: ValueKey(productsProvider.similarProducts!.results[index].id),
                           product: productsProvider.similarProducts!.results[index],
                           index: index,
                           checkCompare: checkCompare,

--- a/lib/ui/widgets/els_product_card.dart
+++ b/lib/ui/widgets/els_product_card.dart
@@ -33,7 +33,9 @@ class ELSProductCard<T extends SummarizedProductDto> extends StatefulWidget {
   State<ELSProductCard> createState() => _ELSProductCardState();
 }
 
-class _ELSProductCardState extends State<ELSProductCard> {
+class _ELSProductCardState extends State<ELSProductCard> with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
   bool isSelected = false;
   bool nowComparing = false;
   final cardHeight = 105.0;
@@ -42,29 +44,27 @@ class _ELSProductCardState extends State<ELSProductCard> {
   @override
   void initState() {
     super.initState();
-    isOnSale = widget.isOnSale!;
-    print(isOnSale);
+    isOnSale = widget.isOnSale;
+  }
+
+  void onItemTapped() {
+    setState(() {
+      isSelected = !isSelected;
+    });
   }
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     final productProvider = Provider.of<ELSProductProvider>(context, listen: false);
     final productsProvider = Provider.of<ELSOnSaleProductsProvider>(context, listen: false);
-    // final isOnSale = widget.product.subscriptionEndDate.difference(DateTime.now()).inDays < 0;
-    final format = DateFormat('yyyy년 MM월 dd일');
     final dayDifference = widget.product.subscriptionEndDate.difference(DateTime.now()).inDays;
-
-    void _onItemTapped() {
-      setState(() {
-        isSelected = !isSelected;
-      });
-    }
 
     return LayoutBuilder(
       builder: (context, constraints) {
         // final width = constraints.maxWidth;
         return GestureDetector(
-          onTap: () => _onItemTapped(),
+          onTap: () => onItemTapped(),
           child: Stack(
             children: [
               _buildHiddenButtons(context, productProvider, productsProvider),
@@ -255,6 +255,7 @@ class _ELSProductCardState extends State<ELSProductCard> {
                     // ELSDetailDialog.show(context, productProvider.product!);
                     Navigator.push(context, MaterialPageRoute(builder: (context) => ELSProductDetailScreen()));
                   }
+                  onItemTapped();
                 },
               ),
             ),

--- a/lib/ui/widgets/stock_price_graph.dart
+++ b/lib/ui/widgets/stock_price_graph.dart
@@ -10,7 +10,7 @@ import 'package:fl_chart/fl_chart.dart';
 class StockPriceGraph extends StatefulWidget {
   int period;
 
-  StockPriceGraph(this.period);
+  StockPriceGraph(this.period, {super.key});
 
   @override
   _StockPriceGraphState createState() => _StockPriceGraphState();
@@ -101,7 +101,6 @@ class _StockPriceGraphState extends State<StockPriceGraph> {
         .expand((data) => data)
         .map((data) => data.y)
         .reduce((a, b) => a < b ? a : b);
-    print('min: $result');
     return result;
   }
 
@@ -110,7 +109,6 @@ class _StockPriceGraphState extends State<StockPriceGraph> {
         .expand((data) => data)
         .map((data) => data.y)
         .reduce((a, b) => a > b ? a : b);
-    print('max: $result');
     return result;
   }
 
@@ -124,14 +122,13 @@ class _StockPriceGraphState extends State<StockPriceGraph> {
         color: colors[index++],
         barWidth: 3,
         belowBarData: BarAreaData(show: false),
-        dotData: FlDotData(show: false,), // 점 표시
+        dotData: const FlDotData(show: false,), // 점 표시
       );
     }).toList();
 
     double minY = findMinY(stockData);
     double maxY = findMaxY(stockData);
     double padding = (maxY - minY) * 0.2; // 20% 여유를 둠
-    print(maxY);
 
     return LineChartData(
       minY: minY - padding,
@@ -200,7 +197,7 @@ class _StockPriceGraphState extends State<StockPriceGraph> {
                 const TextStyle(),
                 children: [
                   if (!isFirst) TextSpan(
-                    text: format.format(touchedDate),
+                    text: '${format.format(touchedDate)}\n',
                     style: const TextStyle(
                       color: Colors.white,
                       fontWeight: FontWeight.bold,


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
#161 
<!---- Resolves: #(Isuue Number) -->
1. 상품 카드의 상태가 초기화가 되지 않도록 수정했습니다.
2. 관심 상품 목록과 같은 위치에서 리스트 아이템이 삭제될 때 이전 아이템이 가지고 있던 상태를 물려받는 현상을, 자세히보기 클릭 시 원래 상태로 되돌아가도록 변경하여 수정했습니다.
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 팀 Notion에 있는 Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
