### PR TITLE
fix: 보유 상품 리스트 중 스텝다운이 아닌 상품 클릭 시 상품 정보를 볼 수 없는 오류 수정

### DIFF
--- a/lib/ui/screens/compare_product_screen.dart
+++ b/lib/ui/screens/compare_product_screen.dart
@@ -594,6 +594,7 @@ class CompareProductScreen extends StatelessWidget {
                     },
                   );
 
+                  await productProvider!.fetchMonteCarloResponse(compareProduct1.id);
                   await productProvider!.fetchProduct(compareProduct1.id);
                   productProvider!.checkisHeld(userProvider!.holdingProducts ?? []);
 
@@ -650,6 +651,7 @@ class CompareProductScreen extends StatelessWidget {
                     },
                   );
 
+                  await productProvider!.fetchMonteCarloResponse(compareProduct2.id);
                   await productProvider!.fetchProduct(compareProduct2.id);
                   productProvider!.checkisHeld(userProvider!.holdingProducts ?? []);
 

--- a/lib/ui/widgets/holding_product_card.dart
+++ b/lib/ui/widgets/holding_product_card.dart
@@ -60,10 +60,10 @@ class _ELSProductCardState extends State<HoldingProductCard> with AutomaticKeepA
       },
     );
 
+    await productProvider.fetchMonteCarloResponse(product.productId);
     final result = [
       await productProvider.fetchProduct(product.productId),
       await productProvider.fetchStockPrices(),
-      await productProvider.fetchMonteCarloResponse(product.productId),
       productProvider.checkisHeld(userProvider.holdingProducts!),
     ].every((result) => result);
 


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
#228 
<!---- Resolves: #(Isuue Number) -->
보유 상품 리스트 중 스텝다운이 아닌 상품 클릭 시 상품 정보를 볼 수 없는 오류를 수정했습니다.
(추가로 상품 비교 화면 내에서 자세히 버튼 클릭 시 분석 결과를 볼 수 없었던 오류도 수정했습니다.)
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 팀 Notion에 있는 Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
