### PR TITLE
fix: iOS 상품 회차 번호 검색 시 완료 버튼이 없어서 검색 안되는 문제 해결

### DIFF
--- a/lib/ui/screens/product/search_product_screen.dart
+++ b/lib/ui/screens/product/search_product_screen.dart
@@ -129,7 +129,7 @@ class _SearchProductScreenState extends State<SearchProductScreen> {
                           filled: true,
                           fillColor: Theme.of(context).scaffoldBackgroundColor,
                         ),
-                        keyboardType: TextInputType.number,
+                        keyboardType: TextInputType.numberWithOptions(signed: true, decimal: false), // done 버튼 있는 숫자 키보드
                         inputFormatters: <TextInputFormatter>[
                           FilteringTextInputFormatter.digitsOnly, // 숫자만 허용
                         ],


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
기존 iOS에서 상품 회차 번호 검색할 때 기본 키보드에 '완료' 버튼이 없어서 상품 검색 기능을 이용할 수 없는 문제를 숫자 + 기호 키보드가 뜨게하고 숫자만 입력할 수 있게 함으로 해결하였다

<!---- Resolves: #(Isuue Number) -->
#276 #277 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 팀 Notion에 있는 Commit message convention 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
